### PR TITLE
BoolRef's _byte attribute changed from pointer to reference

### DIFF
--- a/include/common/base/array.hpp
+++ b/include/common/base/array.hpp
@@ -441,7 +441,7 @@ public:
   //! \param i : the index of the element to access.
   //! \return The reference to the element contained at the specified index.
   inline ElementRef operator[](array_t i) {
-    return BoolRef(&_elements[i / 8], i % 8);
+    return BoolRef(_elements[i / 8], i % 8);
   }
   
   //! \brief Access to an element's constant reference via its field's index.

--- a/include/common/base/bool_ref.hpp
+++ b/include/common/base/bool_ref.hpp
@@ -26,7 +26,7 @@
 class BoolRef {
 private:
   //! \brief The address where the boolean is stored.
-  u8* _byte;
+  u8& _byte;
   
   //! \brief The mask to retrieve the required bit.
   u8 _mask;
@@ -38,7 +38,7 @@ public:
   //! \brief Constructor to reference a boolean within a byte.
   //! \param byte : the address where the boolean is stored.
   //! \param bit : the index of the bit at which the boolean is stored.
-  inline BoolRef(u8* byte, u8 bit)
+  inline BoolRef(u8& byte, u8 bit)
     : _byte(byte), _mask(1 << bit) {
   }
   
@@ -46,7 +46,7 @@ public:
   //! \warning This assumes that the boolean is coded by the first bit at the address of the given boolean, however, how a boolean is represented in memory is platform-dependent.
   //! \todo Investigate how are booleans reprensented in memory on the supported platforms by Aversive++ and possibly specialise this method per platform (according to the first test, it works on x86-64).
   inline BoolRef(const bool& b)
-    : _byte((u8*) &b), _mask(1) {
+    : _byte((u8&) b), _mask(1) {
   }
   
   //! \brief Copy constructor, the new BoolRef references the same boolean.
@@ -57,7 +57,7 @@ public:
   //! \brief Cast operator to retrieve a regular C++ boolean representing the referenced boolean.
   //! \return A regular C++ boolean.
   inline operator bool(void) const {
-    return (bool) (*_byte & _mask);
+    return (bool) (_byte & _mask);
   }
   
   //! \brief Assign a new value to the referenced boolean.
@@ -65,10 +65,10 @@ public:
   //! \return A reference to the BoolRef.
   inline BoolRef& operator=(bool b) {
     if(b) {
-      *_byte |= _mask;
+      _byte |= _mask;
     }
     else {
-      *_byte &= ~_mask;
+      _byte &= ~_mask;
     }
     
     return (*this);

--- a/include/common/base/pair.hpp
+++ b/include/common/base/pair.hpp
@@ -166,13 +166,13 @@ public:
   //! \brief Access the left member.
   //! \return The reference to the left member.
   inline LeftRef left(void) {
-    return BoolRef(&_pair, 1);
+    return BoolRef(_pair, 1);
   }
   
   //! \brief Access the right member.
   //! \return The reference to the right member.
   inline RightRef right(void) {
-    return BoolRef(&_pair, 0);
+    return BoolRef(_pair, 0);
   }
   
   //! \brief Access the left member (constant version).

--- a/tests/bool_ref/main.cpp
+++ b/tests/bool_ref/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
   u8 b2 = 0xF0;
   
   for(int i = 0; i < 4; i++) {
-    BoolRef r(&b2, i);
+    BoolRef r(b2, i);
     if(r) {
       std::cout << "NOK" << std::endl;
       return 1;
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
   }
   
   for(int i = 4; i < 8; i++) {
-    BoolRef r(&b2, i);
+    BoolRef r(b2, i);
     if(!r) {
       std::cout << "NOK" << std::endl;
       return 1;


### PR DESCRIPTION
This PR answer the last bit added to issue #11.

You can run the appropriate tests in `tests/bool_ref`, `tests/bool_pair` and `tests/bool_array` by typing `make sasiae && ./robot_sasiae.elf` (Yes, it is still the old way).
