### PR TITLE
Debug string_stream.hpp, this fixes issue #62

### DIFF
--- a/include/avr/device/stream/string_stream.hpp
+++ b/include/avr/device/stream/string_stream.hpp
@@ -19,7 +19,7 @@
 #ifndef AVR_STRING_STREAM_HPP
 #define AVR_STRING_STREAM_HPP
 
-#include "../../../../common//device/stream/string_stream.hpp"
+#include "../../../common/device/stream/string_stream.hpp"
 
 
 

--- a/include/sasiae/device/stream/string_stream.hpp
+++ b/include/sasiae/device/stream/string_stream.hpp
@@ -19,7 +19,7 @@
 #ifndef SASIAE_STRING_STREAM_HPP
 #define SASIAE_STRING_STREAM_HPP
 
-#include "../../../../common//device/stream/string_stream.hpp"
+#include "../../../common/device/stream/string_stream.hpp"
 
 
 

--- a/include/stm32/device/stream/string_stream.hpp
+++ b/include/stm32/device/stream/string_stream.hpp
@@ -19,7 +19,7 @@
 #ifndef STM32_STRING_STREAM_HPP
 #define STM32_STRING_STREAM_HPP
 
-#include "../../../../common//device/stream/string_stream.hpp"
+#include "../../../common/device/stream/string_stream.hpp"
 
 
 


### PR DESCRIPTION
The string_streams.hpp files in sasiae/avr/stm32 implementations redirected to a wrong path.
The string_stream test use common include path, and did not test sasiae's one for example, that is why we didn't see that before.

Even if redirection headers should be removed for v15.09, this correction could be added to a v14.11a release ?