### PR TITLE
Bug correction in bool_ref test.

### DIFF
--- a/include/common/base/bool_ref.hpp
+++ b/include/common/base/bool_ref.hpp
@@ -36,7 +36,7 @@ private:
   
 public:
   //! \brief Constructor to reference a boolean within a byte.
-  //! \param byte : a reference to the boolean to reference with this BoolRef.
+  //! \param byte : a reference to the byte where the boolean is stored.
   //! \param bit : the index of the bit at which the boolean is stored.
   inline BoolRef(u8& byte, u8 bit)
     : _byte(byte), _mask(1 << bit) {

--- a/include/common/base/bool_ref.hpp
+++ b/include/common/base/bool_ref.hpp
@@ -36,7 +36,7 @@ private:
   
 public:
   //! \brief Constructor to reference a boolean within a byte.
-  //! \param byte : the address where the boolean is stored.
+  //! \param byte : a reference to the boolean to reference with this BoolRef.
   //! \param bit : the index of the bit at which the boolean is stored.
   inline BoolRef(u8& byte, u8 bit)
     : _byte(byte), _mask(1 << bit) {

--- a/tests/common/base/bool_ref/main.cpp
+++ b/tests/common/base/bool_ref/main.cpp
@@ -26,13 +26,13 @@ int main(int argc, char** argv) {
   u8 b2 = 0xF0;
   
   for(int i = 0; i < 4; i++) {
-    BoolRef r(&b2, i);
+    BoolRef r(b2, i);
     myAssert(!r, "Line " S__LINE__ ": Construction to reference a bit within a byte, r should be false.");
     r = !r;
   }
   
   for(int i = 4; i < 8; i++) {
-    BoolRef r(&b2, i);
+    BoolRef r(b2, i);
     myAssert(r, "Line " S__LINE__ ": Construction to reference a bit within a byte, r should be true.");
     r = !r;
   }


### PR DESCRIPTION
The bool_ref test could not compile because an address was sent t the constructor, and not a refference.

Now all the common and sasiae tests should compile.